### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -4,7 +4,7 @@ from numpy.random import uniform
 from functools import reduce
 
 def logsubexp(x,y):
-        assert np.all(x >= y), 'cannot take log of negative number %s - %s'%(str(x),str(y))
+        assert np.all(x >= y), 'cannot take log of negative number {0!s} - {1!s}'.format(str(x), str(y))
 
         return x + np.log1p(-np.exp(y-x))
 
@@ -61,27 +61,27 @@ def draw_posterior_many(datas, Nlives, verbose=False):
     and weight according to the evidence in each input run"""
     # list of log_evidences, log_weights
     log_evs,log_wts=zip(*[compute_weights(data['logL'],Nlive) for data,Nlive in zip(datas, Nlives)])
-    if verbose: print('Computed log_evidences: %s'%(str(log_evs)))
+    if verbose: print('Computed log_evidences: {0!s}'.format((str(log_evs))))
 
     log_total_evidence=reduce(logaddexp, log_evs)
     log_max_evidence=max(log_evs)
     #print 'evidences: %s'%(str(log_evs))
     fracs=[np.exp(log_ev-log_max_evidence) for log_ev in log_evs]
-    if verbose: print('Relative weights of input files: %s'%(str(fracs)))
+    if verbose: print('Relative weights of input files: {0!s}'.format((str(fracs))))
     Ns=[fracs[i]/len(datas[i]) for i in range(len(fracs))]
     Ntot=max(Ns)
     fracs=[n/Ntot for n in Ns]
-    if verbose: print('Relative weights of input files taking into account their length: %s'%(str(fracs)))
+    if verbose: print('Relative weights of input files taking into account their length: {0!s}'.format((str(fracs))))
 
     posts=[draw_posterior(data,logwt) for (data,logwt,logZ) in zip(datas,log_wts,log_evs)]
-    if verbose: print('Number of input samples: %s'%(str([len(x) for x in log_wts])))
-    if verbose: print('Expected number of samples from each input file %s'%(str([int(f*len(p)) for f,p in zip(fracs,posts)])))
+    if verbose: print('Number of input samples: {0!s}'.format((str([len(x) for x in log_wts]))))
+    if verbose: print('Expected number of samples from each input file {0!s}'.format((str([int(f*len(p)) for f,p in zip(fracs,posts)]))))
     bigpos=[]
     for post,frac in zip(posts,fracs):
       mask = uniform(size=len(post))<frac
       bigpos.append(post[mask])
     result = vstack(bigpos)
-    if verbose: print('Samples produced: %s'%(str(result.shape)))
+    if verbose: print('Samples produced: {0!s}'.format((str(result.shape))))
     return result
     
 def draw_N_posterior(data,log_wts, N, verbose=False):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:johnveitch:cpnest?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:johnveitch:cpnest?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)