### PR TITLE
Testing evidence evaluation with the 1d Gaussian model

### DIFF
--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -9,7 +9,7 @@ class CPNest(object):
     """
     Class to control CPNest sampler
     """
-    def __init__(self,userclass,Nlive=100,output='./',verbose=0,seed=None,maxmcmc=100,Nthreads=None):
+    def __init__(self,userclass,Nlive=100,output='./',verbose=0,seed=None,maxmcmc=100,Nthreads=None,poolsize=100,proposals=None,proposalweights=None):
         if Nthreads is None:
             Nthreads = mp.cpu_count()
         print('Running with {0} parallel threads'.format(Nthreads))
@@ -22,7 +22,7 @@ class CPNest(object):
         else:
             self.seed=seed
         self.NS = NestedSampler(self.user,Nlive=Nlive,output=output,verbose=verbose,seed=self.seed,prior_sampling=False)
-        self.Evolver = Sampler(self.user,maxmcmc,verbose=0)
+        self.Evolver = Sampler(self.user,maxmcmc,verbose=0,poolsize=poolsize,proposals=proposals,proposalweights=proposalweights)
         self.NUMBER_OF_PRODUCER_PROCESSES = Nthreads
         self.NUMBER_OF_CONSUMER_PROCESSES = 1
 

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -6,6 +6,8 @@ from abc import ABCMeta,abstractmethod
 import random
 from random import sample,gauss,randrange,uniform
 
+proposalnames = ['EnsembleWalk', 'EnsembleStretch', 'EnsembleEigenVector', 'DifferentialEvolution']
+
 class Proposal(object):
     """
     Base class for jump proposals

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -36,7 +36,8 @@ class Sampler(object):
         self.maxmcmc = maxmcmc
         self.Nmcmc = maxmcmc
         self.Nmcmc_exact = float(maxmcmc)
-        self.proposals = proposal.DefaultProposalCycle()
+        #self.proposals = proposal.DefaultProposalCycle()
+        self.proposals = proposal.ProposalCycle([proposal.EnsembleWalk()], weights=[1.0]) # hardcode proposal to use walk
         self.poolsize = poolsize
         self.evolution_points = deque(maxlen=self.poolsize)
         self.verbose=verbose

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -61,4 +61,3 @@ def test_all():
 
 if __name__=='__main__':
     unittest.main(verbosity=2)
- 

--- a/tests/test_1d_walk.py
+++ b/tests/test_1d_walk.py
@@ -47,16 +47,28 @@ bounds = [[0., 1e8]]
 mean = 0.
 sigma = 1.0
 
-model = GaussianModel(mean=mean, sigma=sigma, bounds=bounds)
-work = cpnest.CPNest(model,verbose=0,Nthreads=3,Nlive=512,maxmcmc=2000)
-work.run()
+proposals = ['EnsembleWalk']
+proposalweights = [1.0]
 
-tolerance = 2.0*np.sqrt(work.NS.state.info/work.NS.Nlive)
-print('2-sigma statistic error in logZ: {0:0.3f}'.format(tolerance))
-print('Analytic logZ {0}'.format(model.analytic_log_Z))
-print('Estimated logZ {0}'.format(work.NS.logZ))
-print('KL divergence {0:0.3f}'.format(model.KLdiv))
+Nlive = 512
+model = GaussianModel(mean=mean, sigma=sigma, bounds=bounds)
+
+logZs = []
+logZratio = []
+errs = []
+
+for i in range(20):
+  work = cpnest.CPNest(model,verbose=0,Nthreads=3,Nlive=Nlive,maxmcmc=2000,poolsize=Nlive,proposals=proposals, proposalweights=proposalweights)
+  work.run()
+
+  errs.append(np.sqrt(work.NS.state.info/work.NS.Nlive))
+  logZs.append(work.NS.logZ)
+  logZratio.append(work.NS.logZ-model.analytic_log_Z)
+  #print('2-sigma statistic error in logZ: {0:0.3f}'.format(tolerance))
+  #print('Analytic logZ {0}'.format(model.analytic_log_Z))
+  #print('Estimated logZ {0}'.format(work.NS.logZ))
+  #print('KL divergence {0:0.3f}'.format(model.KLdiv))
 
 # get posterior samples
-pos = work.posterior_samples['x']
+#pos = work.posterior_samples['x']
 

--- a/tests/test_1d_walk.py
+++ b/tests/test_1d_walk.py
@@ -50,24 +50,31 @@ sigma = 1.0
 proposals = ['EnsembleWalk']
 proposalweights = [1.0]
 
-Nlive = 512
+Nlives = [512, 1024, 2048]
+niter = 25
 model = GaussianModel(mean=mean, sigma=sigma, bounds=bounds)
 
 logZs = []
 logZratio = []
 errs = []
 
-for i in range(20):
-  work = cpnest.CPNest(model,verbose=0,Nthreads=3,Nlive=Nlive,maxmcmc=2000,poolsize=Nlive,proposals=proposals, proposalweights=proposalweights)
-  work.run()
+for j in Nlives:
+  lZ = []
+  lZr = []
+  er = []
+  for i in range(niter):
+    work = cpnest.CPNest(model, verbose=0, Nthreads=3, Nlive=j, maxmcmc=2000, poolsize=j, proposals=proposals, proposalweights=proposalweights)
+    work.run()
 
-  errs.append(np.sqrt(work.NS.state.info/work.NS.Nlive))
-  logZs.append(work.NS.logZ)
-  logZratio.append(work.NS.logZ-model.analytic_log_Z)
-  #print('2-sigma statistic error in logZ: {0:0.3f}'.format(tolerance))
-  #print('Analytic logZ {0}'.format(model.analytic_log_Z))
-  #print('Estimated logZ {0}'.format(work.NS.logZ))
-  #print('KL divergence {0:0.3f}'.format(model.KLdiv))
+    er.append(np.sqrt(work.NS.state.info/work.NS.Nlive))
+    lZ.append(work.NS.logZ)
+    lZr.append(work.NS.logZ-model.analytic_log_Z)
+
+    del work
+
+  logZs.append(lZ)
+  logZratio.append(lZr)
+  errs.append(er)
 
 # get posterior samples
 #pos = work.posterior_samples['x']

--- a/tests/test_1d_walk.py
+++ b/tests/test_1d_walk.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, division
+
+import numpy as np
+from scipy import integrate,stats
+from scipy.special import erf
+import cpnest
+import cpnest.model
+
+class GaussianModel(cpnest.model.Model):
+    """
+    A simple gaussian model with parameters mean and sigma
+    """
+    def __init__(self, mean=0., sigma=1.0, bounds=[[0., 10]]):
+        self.distr = stats.norm(loc=mean,scale=sigma)
+        self.mean = mean
+        self.sigma = sigma
+        self.bounds = bounds
+        inv_sqrt2 = 1./np.sqrt(2.)
+        minv = self.bounds[0][0]
+        maxv = self.bounds[0][1]
+        lnC = -np.log(maxv - minv)
+        self._analytic_log_Z = np.log(0.5*(erf(inv_sqrt2*(self.mean - minv)/self.sigma) - erf(inv_sqrt2*(self.mean - maxv)/self.sigma)))
+        self._analytic_log_Z += lnC # divide by prior
+
+        D = np.sqrt(2.*np.pi*self.sigma*self.sigma)
+        Cpart = 0.25*(1. + 2.*lnC + 2.*np.log(D));
+        self._KLdiv = (0.5/D)*np.exp(-0.5*((maxv-self.mean)/self.sigma)*((maxv-self.mean)/self.sigma))*(maxv-self.mean) - Cpart*erf(inv_sqrt2*(maxv-self.mean)/self.sigma)
+        self._KLdiv -= ((0.5/D)*np.exp(-0.5*((minv-self.mean)/self.sigma)*((minv-self.mean)/self.sigma))*(minv-self.mean) - Cpart*erf(inv_sqrt2*(minv-self.mean)/self.sigma))
+    
+    names=['x']
+
+    def log_likelihood(self,p):
+        return self.distr.logpdf(p['x'])
+        #return -0.5*(p['x']**2) - 0.5*np.log(2.0*np.pi)
+        
+    @property
+    def analytic_log_Z(self):
+        return self._analytic_log_Z
+    
+    @property
+    def KLdiv(self):
+        return self._KLdiv
+
+bounds = [[0., 1e8]]
+mean = 0.
+sigma = 1.0
+
+model = GaussianModel(mean=mean, sigma=sigma, bounds=bounds)
+work = cpnest.CPNest(model,verbose=0,Nthreads=3,Nlive=512,maxmcmc=2000)
+work.run()
+
+tolerance = 2.0*np.sqrt(work.NS.state.info/work.NS.Nlive)
+print('2-sigma statistic error in logZ: {0:0.3f}'.format(tolerance))
+print('Analytic logZ {0}'.format(model.analytic_log_Z))
+print('Estimated logZ {0}'.format(work.NS.logZ))
+print('KL divergence {0:0.3f}'.format(model.KLdiv))
+
+# get posterior samples
+pos = work.posterior_samples['x']
+


### PR DESCRIPTION
Here's the start of my testing cpnests evidence estimation for the different proposals when using the simple 1D Gaussian likelihood.

To do this I've had to make some changes to the CPNest and Sampler class initialisations, which you may or may not want to implement in the production code. I've allowed you to input lists of the proposal names and weights that you want to use (this isn't done very elegantly at the moment!), and the `poolsize` to use for the ensemble, when initialising the CPNest class. This allows me to test thing more easily against what I see with the `LALInference` sampler (for which the poolsize is the number of live points by default).

There is also a `test_1d_walk.py` script in which I define the 1d Gaussian with a given prior bound range and run the nested sampling 20 times. For the case of just using the ensemble walk proposal, 512 live points (and the same number of pool points), and a KL divergence between the prior and posterior of 8.5 nats, I find that the estimated evidence is actually consistent with the true analytical evidence (the log of the ratio has a small mean, approx -0.1, and a standard deviation that very well matches that estimated from sqrt(information/Nlive)). This is inconsistent with what I was seeing from the `LALInference` version shown in this [plot](https://github.com/mattpitkin/CW_nested_sampling_doc/blob/master/figures/proptesting/walk_prop/evidences/collate_plots_wp_evidences.png).

There is some evidence that there are still problems if I leave the default pool size as 100, but I'll need to do some more testing (with different KL divergence ranges and numbers of live points). Feel free to play around with the test to.