### PR TITLE
Make the returned posterior samples array same dimensionality as the nested samples array

### DIFF
--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -84,8 +84,8 @@ def draw_posterior_many(datas, Nlives, verbose=False):
     for post,frac in zip(posts,fracs):
       mask = uniform(size=len(post))<frac
       bigpos.append(post[mask])
-    result = vstack(bigpos)
-    if verbose: print('Samples produced: {0:d}'.format(result.shape[1]))
+    result = vstack(bigpos).flatten()
+    if verbose: print('Samples produced: {0:d}'.format(result.shape[0]))
     return result
     
 def draw_N_posterior(data,log_wts, N, verbose=False):
@@ -117,5 +117,5 @@ def draw_N_posterior_many(datas, Nlives, Npost, verbose=False):
     log_total_evidence=reduce(logaddexp, log_evs)
     Ns=[int(round(Npost*np.exp(log_ev-log_total_evidence))) for log_ev in log_evs]
     posts=[draw_N_posterior(data,logwt,N) for (data,logwt,N) in zip(datas,log_wts,Ns)]
-    return vstack(posts)
+    return vstack(posts).flatten()
 


### PR DESCRIPTION
Currently the dimensionality of the array containing the nested samples is different than the dimensionality of the array containing the posterior samples, e.g.

    >>> print work.nested_samples.shape
    (12345, )
    >>> print work.posterior_samples.shape
    (1, 1234)

So, if I want to access and plot a parameter (let's say `h0`) from the nested samples array I could just do

    plt.hist(work.nested_samples['h0'])

but, if I want to get the same thing for the posterior samples I have to do

    plt.hist(work.posterior_samples[0]['h0'])

otherwise just using `work.posterior_samples['h0'])` tries to produce 1234 overlaid histograms. This patch just makes sure that posterior samples is e.g. a `(1234,)` array.