### PR TITLE
Nlive p

### DIFF
--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -236,14 +236,10 @@ class NestedSampler(object):
         # send all live points to the samplers for start
         i = 0
         while i < self.Nlive:
-            for j in range(len(consumer_pipes)):
-#                print("NS sending message",i,"to sampler",j)
-                consumer_pipes[j].send(self.model.new_point())
+            for j in range(len(consumer_pipes)): consumer_pipes[j].send(self.model.new_point())
             for j in range(len(consumer_pipes)):
                 while True:
-#                    print("NS receiving from sampler",self.queue_counter)
                     self.acceptance,self.jumps,self.params[i] = consumer_pipes[self.queue_counter].recv()
-#                    print("NS received",self.params[i])
                     self.queue_counter = (self.queue_counter + 1) % len(consumer_pipes)
                     if self.params[i].logP!=-np.inf and self.params[i].logL!=-np.inf:
                         i+=1
@@ -272,13 +268,6 @@ class NestedSampler(object):
         self.logLmin.value = np.inf
         for c in consumer_pipes:
             c.send(None)
-#        # Flush the queue so subsequent join can succeed
-#        for q in result_queues:
-#            while True:
-#              try:
-#                _ = q.get_nowait()
-#              except Empty:
-#                break
 
         # final adjustments
         self.params.sort(key=attrgetter('logL'))

--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -231,13 +231,16 @@ class NestedSampler(object):
         """
         main nested sampling loop
         """
+        # send all live points to the samplers for start
+        for i in range(self.Nlive):
+            job_queues[(i + 1) % len(job_queues)].put(self.model.new_point())
         for i in range(self.Nlive):
             while True:
-                job_queues[self.queue_counter].put(self.model.new_point())
                 self.acceptance,self.jumps,self.params[i] = result_queues[self.queue_counter].get()
                 self.queue_counter = (self.queue_counter + 1) % len(result_queues)
                 if self.params[i].logP!=-np.inf or self.params[i].logL!=-np.inf:
                     break
+
             if self.verbose:
                 sys.stderr.write("sampling the prior --> {0:.0f} % complete\r".format((100.0*float(i+1)/float(self.Nlive))))
                 sys.stderr.flush()

--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -194,7 +194,7 @@ class NestedSampler(object):
         logLmin = self.get_worst_n_live_points(len(job_queues))
         for k in self.worst:
             self.state.increment(self.params[k].logL)
-            job_queues[k].put(self.params[k])
+            job_queues[k].put(self.params[k], False)
             self.output_sample(self.params[k])
         self.condition = logaddexp(self.state.logZ,self.logLmax - self.iteration/(float(self.Nlive))) - self.state.logZ
         

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -40,25 +40,23 @@ class CPNest(object):
         self.NS = NestedSampler(self.user,Nlive=Nlive,output=output,verbose=verbose,seed=self.seed,prior_sampling=False)
 
         self.process_pool = []
-        # We set the queues to be no longer than Nlive, so the samplers cannot too far ahead of each other
-        if balance_samplers:
-            self.result_queues = [mp.Queue(maxsize=Nlive) for _ in range(Nthreads)]
-            self.job_queues = [mp.Queue() for _ in range(Nthreads)]
-        else:
-            self.result_queues = [mp.Queue(maxsize=Nlive)]
-            self.job_queues = [mp.Queue()]
-            
+        
+#        # We set the queues to be no longer than Nlive, so the samplers cannot too far ahead of each other
+#        if balance_samplers:
+#            self.result_queues = [mp.Queue(maxsize=Nlive) for _ in range(Nthreads)]
+#            self.job_queues = [mp.Queue() for _ in range(Nthreads)]
+#        else:
+#            self.result_queues = [mp.Queue(maxsize=Nlive)]
+#            self.job_queues = [mp.Queue()]
+
+        self.consumer_pipes = []
         for i in range(Nthreads):
             sampler = Sampler(self.user,maxmcmc,verbose=verbose,output=output,poolsize=Poolsize,seed=self.seed+i )
-            jq=self.job_queues[i]
-            if balance_samplers:
-                rq=self.result_queues[i]
-            else:
-                rq=self.result_queues[0]
-            
-            p = mp.Process(target=sampler.produce_sample, args=(jq, rq, self.NS.logLmin, ))
+            # We set up pipes between the nested sampling and the various sampler processes
+            consumer, producer = mp.Pipe(duplex=True)
+            self.consumer_pipes.append(consumer)
+            p = mp.Process(target=sampler.produce_sample, args=(producer, self.NS.logLmin, ))
             self.process_pool.append(p)
-
 
     def run(self):
         """
@@ -70,13 +68,14 @@ class CPNest(object):
 
         for each in self.process_pool:
             each.start()
-        self.NS.nested_sampling_loop(self.result_queues, self.job_queues)
-        for q in self.result_queues:
-            while not q.empty():
-                q.get(timeout=1)
-        for q in self.job_queues:
-            while not q.empty():
-                q.get(timeout=1)
+        
+        self.NS.nested_sampling_loop(self.consumer_pipes)
+#        for q in self.result_queues:
+#            while not q.empty():
+#                q.get(timeout=1)
+#        for q in self.job_queues:
+#            while not q.empty():
+#                q.get(timeout=1)
         for each in self.process_pool:
             each.join()
 

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -40,14 +40,6 @@ class CPNest(object):
         self.NS = NestedSampler(self.user,Nlive=Nlive,output=output,verbose=verbose,seed=self.seed,prior_sampling=False)
 
         self.process_pool = []
-        
-#        # We set the queues to be no longer than Nlive, so the samplers cannot too far ahead of each other
-#        if balance_samplers:
-#            self.result_queues = [mp.Queue(maxsize=Nlive) for _ in range(Nthreads)]
-#            self.job_queues = [mp.Queue() for _ in range(Nthreads)]
-#        else:
-#            self.result_queues = [mp.Queue(maxsize=Nlive)]
-#            self.job_queues = [mp.Queue()]
 
         self.consumer_pipes = []
         for i in range(Nthreads):
@@ -70,12 +62,7 @@ class CPNest(object):
             each.start()
         
         self.NS.nested_sampling_loop(self.consumer_pipes)
-#        for q in self.result_queues:
-#            while not q.empty():
-#                q.get(timeout=1)
-#        for q in self.job_queues:
-#            while not q.empty():
-#                q.get(timeout=1)
+
         for each in self.process_pool:
             each.join()
 

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -43,19 +43,18 @@ class CPNest(object):
         # We set the queues to be no longer than Nlive, so the samplers cannot too far ahead of each other
         if balance_samplers:
             self.result_queues = [mp.Queue(maxsize=Nlive) for _ in range(Nthreads)]
-            self.job_queues = [mp.Queue(maxsize=Nlive) for _ in range(Nthreads)]
+            self.job_queues = [mp.Queue() for _ in range(Nthreads)]
         else:
             self.result_queues = [mp.Queue(maxsize=Nlive)]
-            self.job_queues = [mp.Queue(maxsize=Nlive)]
+            self.job_queues = [mp.Queue()]
             
         for i in range(Nthreads):
             sampler = Sampler(self.user,maxmcmc,verbose=verbose,output=output,poolsize=Poolsize,seed=self.seed+i )
+            jq=self.job_queues[i]
             if balance_samplers:
                 rq=self.result_queues[i]
-                jq=self.job_queues[i]
             else:
                 rq=self.result_queues[0]
-                jq=self.job_queues[0]
             
             p = mp.Process(target=sampler.produce_sample, args=(jq, rq, self.NS.logLmin, ))
             self.process_pool.append(p)

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -180,6 +180,6 @@ class DefaultProposalCycle(ProposalCycle):
     """
     def __init__(self,*args,**kwargs):
         proposals = [EnsembleWalk(), EnsembleStretch(), DifferentialEvolution(), EnsembleEigenVector()]
-        weights = [1.0,1.0,1.0,1.0]
+        weights = [1.0,1.0,3.0,10.0]
         super(DefaultProposalCycle,self).__init__(proposals,weights,*args,**kwargs)
 

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -132,7 +132,7 @@ class Sampler(object):
 
             #outParam = self.evolution_points[np.random.randint(self.poolsize)]
             # Push the sample onto the queue
-            result_queue.put((acceptance,Nmcmc,outParam))
+            result_queue.put((acceptance,Nmcmc,outParam),False)
             # Update the ensemble every now and again
 
             if (self.counter%(self.poolsize/10))==0 or acceptance < 1.0/float(self.poolsize):

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -180,6 +180,7 @@ class Sampler(object):
         
             # Put sample back in the stack
             self.evolution_points.append(oldparam)
+            if self.verbose >=3: self.samples.append(oldparam)
             self.sub_acceptance = float(sub_accepted)/float(sub_counter)
             self.estimate_nmcmc()
             accepted += sub_accepted

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -108,7 +108,7 @@ class Sampler(object):
 
         return self.Nmcmc
 
-    def produce_sample(self, queue, logLmin ):
+    def produce_sample(self, job_queue, result_queue, logLmin ):
         """
         main loop that generates samples and puts them in the queue for the nested sampler object
         """
@@ -116,19 +116,23 @@ class Sampler(object):
         if not self.initialised:
           self.reset()
         # Prevent process from zombification if consumer thread exits
-        queue.cancel_join_thread()
+        job_queue.cancel_join_thread()
         self.counter=0
         
         while True:
             if logLmin.value==np.inf:
-                queue.close()
+                job_queue.close()
                 break
 
+            p = job_queue.get()
+            if p is None:
+                break
+            self.evolution_points.append(p)
             (acceptance,Nmcmc,outParam) = next(self.metropolis_hastings(logLmin.value))
 
             #outParam = self.evolution_points[np.random.randint(self.poolsize)]
             # Push the sample onto the queue
-            queue.put((acceptance,Nmcmc,outParam))
+            result_queue.put((acceptance,Nmcmc,outParam))
             # Update the ensemble every now and again
 
             if (self.counter%(self.poolsize/10))==0 or acceptance < 1.0/float(self.poolsize):

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -41,7 +41,7 @@ class Sampler(object):
 
         self.seed = seed
         self.user = usermodel
-        self.initial_mcmc = maxmcmc//2
+        self.initial_mcmc = maxmcmc//10
         self.maxmcmc = maxmcmc
 
         if proposal is None:
@@ -124,7 +124,7 @@ class Sampler(object):
                 break
 
             p = producer_pipe.recv()
-#            print ("sampler received",p)
+
             if p is None:
                 break
             self.evolution_points.append(p)

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -115,8 +115,7 @@ class Sampler(object):
 
         if not self.initialised:
           self.reset()
-#        # Prevent process from zombification if consumer thread exits
-#        job_queue.cancel_join_thread()
+
         self.counter=0
         
         while True:
@@ -127,13 +126,12 @@ class Sampler(object):
 
             if p is None:
                 break
+            
             self.evolution_points.append(p)
             (acceptance,Nmcmc,outParam) = next(self.metropolis_hastings(logLmin.value))
 
-            #outParam = self.evolution_points[np.random.randint(self.poolsize)]
-            # Push the sample onto the queue
+            # Send the sample to the Nested Sampler
             producer_pipe.send((acceptance,Nmcmc,outParam))
-#            print ("sampler sent",outParam)
             # Update the ensemble every now and again
 
             if (self.counter%(self.poolsize/10))==0 or acceptance < 1.0/float(self.poolsize):

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -57,6 +57,8 @@ class Sampler(object):
         self.verbose=verbose
         self.acceptance=0.0
         self.sub_acceptance=0.0
+        self.mcmc_accepted = 0
+        self.mcmc_counter = 0
         self.initialised=False
         self.output = output
         self.samples = [] # the list of samples from the mcmc chain
@@ -149,15 +151,13 @@ class Sampler(object):
                        self.mcmc_samples.ravel(),header=' '.join(self.mcmc_samples.dtype.names),
                        newline='\n',delimiter=' ')
             sys.stderr.write("Sampler process {0!s}: saved {1:d} mcmc samples in {2!s}\n".format(os.getpid(),len(self.samples),'mcmc_chain_%s.dat'%os.getpid()))
-        sys.stderr.write("Sampler process {0!s}: exiting\n".format(os.getpid()))
+        sys.stderr.write("Sampler process {0!s} - mean acceptance {1:.3f}: exiting\n".format(os.getpid(), float(self.mcmc_accepted)/float(self.mcmc_counter)))
         return 0
 
     def metropolis_hastings(self, logLmin):
         """
         metropolis-hastings loop to generate the new live point taking nmcmc steps
         """
-        accepted = 0
-        counter = 0
         for j in range(self.poolsize):
             sub_counter = 0
             sub_accepted = 0
@@ -182,10 +182,8 @@ class Sampler(object):
             if self.verbose >=3: self.samples.append(oldparam)
             self.sub_acceptance = float(sub_accepted)/float(sub_counter)
             self.estimate_nmcmc()
-            accepted += sub_accepted
-            counter += sub_counter
+            self.mcmc_accepted += sub_accepted
+            self.mcmc_counter += sub_counter
             # Yield the new sample
             if oldparam.logL > logLmin:
                 yield (float(self.sub_acceptance),sub_counter,oldparam)
-
-        self.acceptance = float(accepted)/float(counter)

--- a/examples/eggbox.py
+++ b/examples/eggbox.py
@@ -6,17 +6,19 @@ class EggboxModel(cpnest.model.Model):
     """
     Eggbox problem from https://arxiv.org/pdf/0809.3437v1.pdf
     """
-    names=['x','y']
-    bounds=[[0,10.0*np.pi],[0,10.0*np.pi]]
+    names=['1','2','3','4','5']
+    bounds=[[0,10.0*np.pi],[0,10.0*np.pi],[0,10.0*np.pi],[0,10.0*np.pi],[0,10.0*np.pi]]
     data = None
     @staticmethod
     def log_likelihood(x):
-        return log_eggbox(x['x'],x['y'])
+        return log_eggbox(x)
 
 
-def log_eggbox(x, y):
-    tmp = 2.0+np.cos(x/2.)*np.cos(y/2.)
-    return tmp**5.0
+def log_eggbox(p):
+    tmp = 1.0
+    for n in p.names:
+        tmp *= np.cos(p[n]/2.)
+    return (tmp+2.0)**5.0
 
 class EggboxTestCase(unittest.TestCase):
     """
@@ -32,6 +34,6 @@ def test_all():
     unittest.main(verbosity=2)
 
 if __name__=='__main__':
-        work=cpnest.CPNest(EggboxModel(),verbose=2,Nthreads=1,Nlive=1000,maxmcmc=1000,Poolsize=1000)
+        work=cpnest.CPNest(EggboxModel(),verbose=3,Nthreads=4,Nlive=1000,maxmcmc=1000,Poolsize=1000)
         work.run()
 

--- a/examples/test_50d.py
+++ b/examples/test_50d.py
@@ -21,7 +21,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model, verbose=3, Nthreads=8, Nlive=1000, maxmcmc=1000, Poolsize=64)
+        self.work=cpnest.CPNest(self.model, verbose=3, Nthreads=8, Nlive=1000, maxmcmc=1000, Poolsize=100)
 
     def test_run(self):
         self.work.run()

--- a/examples/test_50d.py
+++ b/examples/test_50d.py
@@ -1,19 +1,21 @@
 import unittest
 import numpy as np
 import cpnest.model
+from scipy import stats
 
 class GaussianModel(cpnest.model.Model):
     """
     An n-dimensional gaussian
     """
     def __init__(self,dim=50):
+        self.distr = stats.norm(loc=0,scale=1.0)
         self.dim=dim
         self.names=['{0}'.format(i) for i in range(self.dim)]
         self.bounds=[[-10,10] for _ in range(self.dim)]
         self.analytic_log_Z=0.0 - sum([np.log(self.bounds[i][1]-self.bounds[i][0]) for i in range(self.dim)])
 
     def log_likelihood(self,p):
-        return -0.5*(sum(x**2 for x in p.values)) - 0.5*self.dim*np.log(2.0*np.pi)
+        return np.sum([-0.5*p[n]**2-0.5*np.log(2.0*np.pi) for n in p.names])##np.sum([self.distr.logpdf(p[n]
 
 class GaussianTestCase(unittest.TestCase):
     """
@@ -21,7 +23,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model, verbose=3, Nthreads=8, Nlive=1000, maxmcmc=1000, Poolsize=100)
+        self.work=cpnest.CPNest(self.model, verbose=3, Nthreads=8, Nlive=1000, maxmcmc=1000, Poolsize=1000)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -28,7 +28,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model,verbose=0,Nlive=500,Nthreads=1,maxmcmc=200,balance_samplers=True)
+        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=8,maxmcmc=200,balance_samplers=True)
         self.work.run()
 
     def test_evidence(self):

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -28,7 +28,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=8,maxmcmc=200,balance_samplers=True)
+        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=4,maxmcmc=200,balance_samplers=True)
         self.work.run()
 
     def test_evidence(self):

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -28,7 +28,7 @@ class GaussianTestCase(unittest.TestCase):
         self.work.run()
         # 2 sigma tolerance
         tolerance = 2.0*np.sqrt(self.work.NS.state.info/self.work.NS.Nlive)
-        self.assertTrue(np.abs(self.work.NS.logZ - GaussianModel.analytic_log_Z)<tolerance, 'Incorrect evidence for normalised distribution: {0} instead of {1}'.format(self.work.NS.logZ ,GaussianModel.analytic_log_Z))
+        self.assertTrue(np.abs(self.work.NS.logZ - GaussianModel.analytic_log_Z)<tolerance, 'Incorrect evidence for normalised distribution: {0} +/- {2} instead of {1}'.format(self.work.NS.logZ ,GaussianModel.analytic_log_Z, tolerance))
 
 def test_all():
     unittest.main(verbosity=2)

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -36,7 +36,7 @@ class RingTestCase(unittest.TestCase):
         print('2-sigma statistic error in logZ: {0:0.3f}'.format(tolerance))
         print('Analytic logZ {0}'.format(self.model.analytic_log_Z))
         print('Estimated logZ {0}'.format(self.work.NS.logZ))
-        self.assertTrue(np.abs(self.work.NS.logZ - RingModel.analytic_log_Z)<tolerance, 'Incorrect evidence for normalised distribution: {0:.3f} instead of {1:.3f}'.format(self.work.NS.logZ,RingModel.analytic_log_Z ))
+        self.assertTrue(np.abs(self.work.NS.logZ - RingModel.analytic_log_Z)<tolerance, 'Incorrect evidence for normalised distribution: {0:.3f} +/ {2:.3f} instead of {1:.3f}'.format(self.work.NS.logZ,RingModel.analytic_log_Z,tolerance ))
 
 def test_all():
     unittest.main(verbosity=2)


### PR DESCRIPTION
This patch introduces the method outlined in http://www.wesleyhenderson.me/pdfs/Parallelized_Nested_Sampling_Henderson_Goggans.pdf to replace N live points at the same time. As a consequence, a jobs queue for each sampler has been introduced. This allows the samplers to kill their own queue (solving the hanging problem), but increases the communication overhead a bit. the N worst live points are sent to the N samplers where they are appended to the pool of evolution points. this on the long run increases the samplers efficiency. moreover, after investigating, the relative weights of the proposals have been tuned. all tests are passed successfully. 