### PR TITLE
Hmc v2

### DIFF
--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -210,10 +210,10 @@ class NestedSampler(object):
             while(True):
                 loops += 1
                 self.acceptance, self.jumps, proposed = consumer_pipes[self.queue_counter].recv()
-                self.queue_counter = (self.queue_counter + 1) % len(consumer_pipes)
-                if proposed.logL>self.logLmin.value:
+                if proposed.logL > self.logLmin.value:
                     # replace worst point with new one
                     self.params[k]=proposed
+                    self.queue_counter = (self.queue_counter + 1) % len(consumer_pipes)
                     break
                 else:
                     # resend it to the producer

--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -215,7 +215,10 @@ class NestedSampler(object):
                     # replace worst point with new one
                     self.params[k]=proposed
                     break
-
+                else:
+                    # resend it to the producer
+                    consumer_pipes[k].send(self.params[k])
+                    
             if self.verbose:
                 sys.stderr.write("{0:d}: n:{1:4d} acc:{2:.3f} sub_acc:{3:.3f} H: {4:.2f} logL {5:.5f} --> {6:.5f} dZ: {7:.3f} logZ: {8:.3f} logLmax: {9:.2f}\n"\
                 .format(self.iteration, self.jumps, self.acceptance/float(loops), self.acceptance, self.state.info,\

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -43,7 +43,16 @@ class CPNest(object):
 
         self.consumer_pipes = []
         for i in range(Nthreads):
-            sampler = Sampler(self.user,maxmcmc,verbose=verbose,output=output,poolsize=Poolsize,seed=self.seed+i )
+            sampler = Sampler(self.user,
+                              maxmcmc,
+                              verbose=verbose,
+                              output=output,
+                              poolsize=Poolsize,
+                              seed=self.seed+i,
+                              potential=self.user.potential,
+                              force=self.user.force,
+                              barrier=self.user.log_likelihood,
+                              constraint=self.user.bounds)
             # We set up pipes between the nested sampling and the various sampler processes
             consumer, producer = mp.Pipe(duplex=True)
             self.consumer_pipes.append(consumer)

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -43,10 +43,6 @@ class CPNest(object):
         self.process_pool = []
 
         self.consumer_pipes = []
-        try:
-            has_force = hasattr(self.user, 'force')
-        except AttributeError:
-            pass
         
         for i in range(Nthreads):
             sampler = Sampler(self.user,

--- a/cpnest/model.py
+++ b/cpnest/model.py
@@ -4,54 +4,70 @@ from .parameter import LivePoint
 from numpy.random import uniform
 
 class Model(object):
-  """
-  Base class for user's model. User should subclass this
-  and implement log_likelihood, names and bounds
-  """
-  __metaclass__ = ABCMeta
-  names=[] # Names of parameters, e.g. ['p1','p2']
-  bounds=[] # Bounds of prior as list of tuples, e.g. [(min1,max1), (min2,max2), ...]
-  def in_bounds(self,param):
     """
-    Checks whether param lies within the bounds
+    Base class for user's model. User should subclass this
+    and implement log_likelihood, names and bounds
     """
-    return all(self.bounds[i][0] < param.values[i] < self.bounds[i][1] for i in range(param.dimension))
-  
-  def new_point(self):
-    """
-    Create a new LivePoint, drawn from within bounds
-    """
-    logP=-inf
-    while(logP==-inf):
-      p = LivePoint(self.names,[uniform(self.bounds[i][0],self.bounds[i][1]) for i,_ in enumerate(self.names)] )
-      logP=self.log_prior(p)
-    return p
-  
-  @abstractmethod
-  def log_likelihood(self,param):
-    """
-    returns log likelihood of given parameter
-    """
-    pass
-  def log_prior(self,param):
-    """
-    Returns log of prior.
-    Default is flat prior within bounds
-    """
-    if self.in_bounds(param):
-      return 0.0
-    else: return -inf
+    __metaclass__ = ABCMeta
+    names=[] # Names of parameters, e.g. ['p1','p2']
+    bounds=[] # Bounds of prior as list of tuples, e.g. [(min1,max1), (min2,max2), ...]
     
-  def strsample(self,sample):
-    """
-    Return a string representation for the sample to be written
-    to the output file. User may overload for additional output
-    """
-    line='\t'.join('{0:.20e}'.format(sample[n]) for n in sample.names)
-    line+='{0:20e}'.format(sample.logL)
-    return line
-  def header(self):
-    """
-    Return a string with the output file header
-    """
-    return '\t'.join(self.names) + '\tlogL'
+    def in_bounds(self,param):
+        """
+        Checks whether param lies within the bounds
+        """
+        return all(self.bounds[i][0] < param.values[i] < self.bounds[i][1] for i in range(param.dimension))
+  
+    def new_point(self):
+        """
+        Create a new LivePoint, drawn from within bounds
+        """
+        logP=-inf
+        while(logP==-inf):
+            p = LivePoint(self.names,[uniform(self.bounds[i][0],self.bounds[i][1]) for i,_ in enumerate(self.names)] )
+            logP=self.log_prior(p)
+        return p
+  
+    @abstractmethod
+    def log_likelihood(self,param):
+        """
+        returns log likelihood of given parameter
+        """
+        pass
+
+    def log_prior(self,param):
+        """
+        Returns log of prior.
+        Default is flat prior within bounds
+        """
+        if self.in_bounds(param):
+            return 0.0
+        else: return -inf
+
+    def potential(self,param):
+        """
+        returns the potential energy as minus the log prior
+        """
+        return -self.log_prior(param)
+
+    @abstractmethod
+    def force(self,param):
+        """
+        returns the force (-grad potential)
+        """
+        pass
+
+    def strsample(self,sample):
+        """
+        Return a string representation for the sample to be written
+        to the output file. User may overload for additional output
+        """
+        line='\t'.join('{0:.20e}'.format(sample[n]) for n in sample.names)
+        line+='{0:20e}'.format(sample.logL)
+        return line
+
+    def header(self):
+        """
+        Return a string with the output file header
+        """
+        return '\t'.join(self.names) + '\tlogL'

--- a/cpnest/plot.py
+++ b/cpnest/plot.py
@@ -22,7 +22,7 @@ def plot_hist(x,name=None,filename=None):
     Produce a histogram
     """
     fig=plt.figure(figsize=(4,3))
-    plt.hist(x,normed=True,bins=int(len(x)/4))
+    plt.hist(x,density=True,bins=int(len(x)/4))
     plt.ylabel('probability density')
     if name is not None:
         plt.xlabel(name)

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -353,7 +353,7 @@ class LeapFrog(HamiltonianProposal):
                 if q[k] > u:
                     q[k] = u - (q[k] - u)
                     p[j] *= -1
-                elif q[k] < l:
+                if q[k] < l:
                     q[k] = l + (l - q[k])
                     p[j] *= -1
         
@@ -427,7 +427,7 @@ class ConstrainedLeapFrog(HamiltonianProposal):
                 if q[k] > u:
                     q[k] = u - (q[k] - u)
                     p[j] *= -1
-                elif q[k] < l:
+                if q[k] < l:
                     q[k] = l + (l - q[k])
                     p[j] *= -1
 

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -196,14 +196,14 @@ class DefaultProposalCycle(ProposalCycle):
             # check if the user has defined a force function and a potential barrier
             if 'force' in kwargs and 'barrier' in kwargs:
                 proposals.append(ConstrainedLeapFrog(**kwargs))#
-                weights.append(0.2)
+                weights.append(0.1)
                 proposals.append(LeapFrog(**kwargs))
                 weights.append(0.1)
             elif 'force' in kwargs:
                 proposals.append(LeapFrog(**kwargs))
                 weights.append(0.1)
-#        proposals = [ConstrainedLeapFrog(**kwargs)]
-#        weights = [1]
+#        proposals = [ConstrainedLeapFrog(**kwargs),LeapFrog(**kwargs)]
+#        weights = [1,1]
         super(DefaultProposalCycle,self).__init__(proposals,weights,*args,**kwargs)
 
 class HamiltonianProposal(EnsembleProposal):
@@ -312,7 +312,7 @@ class HamiltonianProposal(EnsembleProposal):
 
         # update the potential energy estimate
         self.update_normal_vector(cov_array, pvals)
-        
+
     def kinetic_energy(self,p):
         """
         kinetic energy part for the Hamiltonian

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -188,7 +188,7 @@ class DefaultProposalCycle(ProposalCycle):
                      EnsembleStretch(),
                      DifferentialEvolution(),
                      EnsembleEigenVector()]
-        weights = [0.3,
+        weights = [0.2,
                    0.2,
                    0.2,
                    0.1]
@@ -196,7 +196,7 @@ class DefaultProposalCycle(ProposalCycle):
             # check if the user has defined a force function and a potential barrier
             if 'force' in kwargs and 'barrier' in kwargs:
                 proposals.append(ConstrainedLeapFrog(**kwargs))#
-                weights.append(0.1)
+                weights.append(0.2)
                 proposals.append(LeapFrog(**kwargs))
                 weights.append(0.1)
             elif 'force' in kwargs:

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -260,7 +260,7 @@ class HamiltonianProposal(EnsembleProposal):
             if window_length%2 == 0: window_length += 1
             f = savgol_filter(Vs[idx], window_length, 5  , deriv=1, delta=0.01, mode='mirror')
             self.normal.append(LSQUnivariateSpline(xs[idx], f, knots, ext = 3, k = 3))
-            np.savetxt('dlogL_spline_%d.txt'%i,np.column_stack((xs[idx],self.normal[-1](xs[idx]),f)))
+#            np.savetxt('dlogL_spline_%d.txt'%i,np.column_stack((xs[idx],self.normal[-1](xs[idx]),f)))
 
     def unit_normal(self, x):
         """

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -189,7 +189,7 @@ class DefaultProposalCycle(ProposalCycle):
                      DifferentialEvolution(),
                      EnsembleEigenVector()]
         weights = [0.3,
-                   0.3,
+                   0.2,
                    0.2,
                    0.1]
         if kwargs is not None:
@@ -202,6 +202,8 @@ class DefaultProposalCycle(ProposalCycle):
             elif 'force' in kwargs:
                 proposals.append(LeapFrog(**kwargs))
                 weights.append(0.1)
+#        proposals = [ConstrainedLeapFrog(**kwargs)]
+#        weights = [1]
         super(DefaultProposalCycle,self).__init__(proposals,weights,*args,**kwargs)
 
 class HamiltonianProposal(EnsembleProposal):
@@ -258,7 +260,7 @@ class HamiltonianProposal(EnsembleProposal):
             if window_length%2 == 0: window_length += 1
             f = savgol_filter(Vs[idx], window_length, 5  , deriv=1, delta=0.01, mode='mirror')
             self.normal.append(LSQUnivariateSpline(xs[idx], f, knots, ext = 3, k = 3))
-#            np.savetxt('potential_%d.txt'%i,np.column_stack((xs[idx],self.normal[-1](xs[idx]),f,Vs[idx])))
+            np.savetxt('dlogL_spline_%d.txt'%i,np.column_stack((xs[idx],self.normal[-1](xs[idx]),f)))
 
     def unit_normal(self, x):
         """
@@ -310,7 +312,7 @@ class HamiltonianProposal(EnsembleProposal):
 
         # update the potential energy estimate
         self.update_normal_vector(cov_array, pvals)
-
+        
     def kinetic_energy(self,p):
         """
         kinetic energy part for the Hamiltonian
@@ -371,7 +373,7 @@ class LeapFrog(HamiltonianProposal):
 
 class ConstrainedLeapFrog(HamiltonianProposal):
     """
-    Leap frog integrator proposal for an costrained
+    Leap frog integrator proposal for a costrained
     (logLmin defines a reflective boundary)
     Hamiltonian Monte Carlo step
     """

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -129,7 +129,7 @@ class Sampler(object):
                 # while the is no data to process, keep the chains running
                 (acceptance,Nmcmc,outParam) = next(self.metropolis_hastings(logLmin.value))
                 self.counter += 1
-                    
+                
             p = producer_pipe.recv()
 
             if p is None:
@@ -141,9 +141,11 @@ class Sampler(object):
             # Send the sample to the Nested Sampler
             producer_pipe.send((acceptance,Nmcmc,outParam))
             # Update the ensemble every now and again
-
-            if (self.counter%(self.poolsize/4))==0: # or acceptance < 1.0/float(self.poolsize)
+            
+            
+            if (self.counter%(self.poolsize//4))==0: # or acceptance < 1.0/float(self.poolsize)
                 self.proposal.set_ensemble(self.evolution_points)
+                self.counter = 0
             self.counter += 1
 
         sys.stderr.write("Sampler process {0!s}: MCMC samples accumulated = {1:d}\n".format(os.getpid(),len(self.samples)))

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -128,7 +128,7 @@ class Sampler(object):
             while not(producer_pipe.poll()):
                 # while the is no data to process, keep the chains running
                 (acceptance,Nmcmc,outParam) = next(self.metropolis_hastings(logLmin.value))
-                self.counter += 1
+
                 
             p = producer_pipe.recv()
 
@@ -141,11 +141,8 @@ class Sampler(object):
             # Send the sample to the Nested Sampler
             producer_pipe.send((acceptance,Nmcmc,outParam))
             # Update the ensemble every now and again
-            
-            
-            if (self.counter%(self.poolsize//4))==0: # or acceptance < 1.0/float(self.poolsize)
+            if (self.counter%(self.poolsize//4))==0.0 or acceptance < 1.0/float(self.poolsize):
                 self.proposal.set_ensemble(self.evolution_points)
-                self.counter = 0
             self.counter += 1
 
         sys.stderr.write("Sampler process {0!s}: MCMC samples accumulated = {1:d}\n".format(os.getpid(),len(self.samples)))

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -125,9 +125,9 @@ class Sampler(object):
             if logLmin.value==np.inf:
                 break
         
-            while not(producer_pipe.poll()):
-                # while the is no data to process, keep the chains running
-                (acceptance,Nmcmc,outParam) = next(self.metropolis_hastings(logLmin.value))
+#            while not(producer_pipe.poll(None)):
+#                # while the is no data to process, keep the chains running
+#                (acceptance,Nmcmc,outParam) = next(self.metropolis_hastings(logLmin.value))
 
                 
             p = producer_pipe.recv()
@@ -141,7 +141,8 @@ class Sampler(object):
             # Send the sample to the Nested Sampler
             producer_pipe.send((acceptance,Nmcmc,outParam))
             # Update the ensemble every now and again
-            if (self.counter%(self.poolsize//4))==0.0 or acceptance < 1.0/float(self.poolsize):
+            if (self.counter%(self.poolsize//10))==0 or acceptance < 1.0/float(self.poolsize):
+                if self.verbose >=3: sys.stderr.write("Sampler process {0!s}: updated statistics\n".format(os.getpid()))
                 self.proposal.set_ensemble(self.evolution_points)
             self.counter += 1
 

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -61,7 +61,7 @@ class Sampler(object):
         self.initialised=False
         self.output = output
         self.samples = [] # the list of samples from the mcmc chain
-        self.ACLs = [] # the history of the ACL of the chain, will be used to thin the output
+        self.ACLs = [] # the history of the ACL of the chain, will be used to thin the output, if requested
         
     def reset(self):
         """

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -191,12 +191,11 @@ class Sampler(object):
                     oldparam = newparam
                     logp_old = newparam.logP
                     sub_accepted+=1
-
             if (sub_counter >= self.Nmcmc and sub_accepted > 0 ) or sub_counter >= self.maxmcmc:
                 break
     
-        # Put sample back in the stack
-        self.evolution_points.append(oldparam)
+        # Put sample back in the stack, unless that sample led to zero accepted points
+        if sub_accepted > 0: self.evolution_points.append(oldparam)
         if self.verbose >=3:
             self.samples.append(oldparam)
         self.sub_acceptance = float(sub_accepted)/float(sub_counter)
@@ -204,8 +203,8 @@ class Sampler(object):
         self.mcmc_accepted += sub_accepted
         self.mcmc_counter += sub_counter
         # Yield the new sample
-        if oldparam.logL > logLmin:
-            yield (float(self.sub_acceptance),sub_counter,oldparam)
+        # if oldparam.logL > logLmin:
+        yield (float(self.sub_acceptance),sub_counter,oldparam)
 
 def autocorrelation (x) :
     """

--- a/examples/eggbox.py
+++ b/examples/eggbox.py
@@ -13,6 +13,9 @@ class EggboxModel(cpnest.model.Model):
     def log_likelihood(x):
         return log_eggbox(x)
 
+    def force(self,x):
+        f = np.zeros(1, dtype = {'names':x.names, 'formats':['f8' for _ in x.names]})
+        return f
 
 def log_eggbox(p):
     tmp = 1.0

--- a/examples/gaussianmixture.py
+++ b/examples/gaussianmixture.py
@@ -19,8 +19,8 @@ class GaussianMixtureModel(cpnest.model.Model):
     @classmethod
     def log_likelihood(cls,x):
         w = x['weight']
-        logL = np.sum([np.logaddexp(np.log(w/(sqrt(2*np.pi)*x['sigma1']))-0.5*((d-x['mean1'])/x['sigma1'])**2,
-                                    np.log((1.0-w)/(sqrt(2*np.pi)*x['sigma2']))-0.5*((d-x['mean2'])/x['sigma2'])**2) 
+        logL = np.sum([np.logaddexp(np.log(w/(np.sqrt(2*np.pi)*x['sigma1']))-0.5*((d-x['mean1'])/x['sigma1'])**2,
+                                    np.log((1.0-w)/(np.sqrt(2*np.pi)*x['sigma2']))-0.5*((d-x['mean2'])/x['sigma2'])**2) 
                        for d in cls.data ] )
         return logL
 

--- a/examples/test_50d.py
+++ b/examples/test_50d.py
@@ -16,6 +16,13 @@ class GaussianModel(cpnest.model.Model):
 
     def log_likelihood(self,p):
         return np.sum([-0.5*p[n]**2-0.5*np.log(2.0*np.pi) for n in p.names])##np.sum([self.distr.logpdf(p[n]
+    
+    def log_prior(self,p):
+        return super(GaussianModel,self).log_prior(p)
+    
+    def force(self, p):
+        f = np.zeros(1, dtype = {'names':p.names, 'formats':['f8' for _ in p.names]})
+        return f
 
 class GaussianTestCase(unittest.TestCase):
     """

--- a/examples/test_50d.py
+++ b/examples/test_50d.py
@@ -30,7 +30,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model, verbose=3, Nthreads=8, Nlive=1000, maxmcmc=1000, Poolsize=1000)
+        self.work=cpnest.CPNest(self.model, verbose=3, Nthreads=4, Nlive=1000, maxmcmc=1000, Poolsize=1000)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -20,7 +20,10 @@ class GaussianModel(cpnest.model.Model):
     def log_likelihood(self,p):
         return self.distr.logpdf(p['x'])
         #return -0.5*(p['x']**2) - 0.5*np.log(2.0*np.pi)
-
+        
+    def force(self, p):
+        f = np.zeros(1, dtype = {'names':p.names, 'formats':['f8' for _ in p.names]})
+        return f
 
 class GaussianTestCase(unittest.TestCase):
     """
@@ -28,7 +31,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=4,maxmcmc=200,balance_samplers=True)
+        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=1,maxmcmc=200,balance_samplers=True)
         self.work.run()
 
     def test_evidence(self):

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -31,7 +31,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=1,maxmcmc=200,balance_samplers=True)
+        self.work=cpnest.CPNest(self.model,verbose=3,Nlive=500,Nthreads=1,maxmcmc=200,balance_samplers=True)
         self.work.run()
 
     def test_evidence(self):

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -31,7 +31,7 @@ class GaussianTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=GaussianModel()
-        self.work=cpnest.CPNest(self.model,verbose=3,Nlive=500,Nthreads=1,maxmcmc=200,balance_samplers=True)
+        self.work=cpnest.CPNest(self.model,verbose=2,Nlive=500,Nthreads=1,maxmcmc=200,balance_samplers=True)
         self.work.run()
 
     def test_evidence(self):

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -27,7 +27,7 @@ class GaussianTestCase(unittest.TestCase):
     Test the gaussian model
     """
     def setUp(self):
-        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=1,Nlive=1000,maxmcmc=1000,Poolsize=1000)
+        self.work=cpnest.CPNest(GaussianModel(),verbose=2,Nthreads=4,Nlive=1000,maxmcmc=1000,Poolsize=1000)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -27,7 +27,7 @@ class GaussianTestCase(unittest.TestCase):
     Test the gaussian model
     """
     def setUp(self):
-        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=4,Nlive=1000,maxmcmc=1000,Poolsize=256)
+        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=1,Nlive=1000,maxmcmc=1000,Poolsize=256)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -27,7 +27,7 @@ class GaussianTestCase(unittest.TestCase):
     Test the gaussian model
     """
     def setUp(self):
-        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=1,Nlive=1000,maxmcmc=1000,Poolsize=256)
+        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=8,Nlive=1000,maxmcmc=1000,Poolsize=256)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -12,17 +12,22 @@ class GaussianModel(cpnest.model.Model):
     bounds=[[-10,10],[-10,10]]
     analytic_log_Z=0.0 - np.log(bounds[0][1]-bounds[0][0]) - np.log(bounds[1][1]-bounds[1][0])
 
-    @classmethod
-    def log_likelihood(cls,p):
+    def log_likelihood(self,p):
         return -0.5*(p['x']**2 + p['y']**2) - np.log(2.0*np.pi)
 
+    def log_prior(self,p):
+        return super(GaussianModel,self).log_prior(p)
+    
+    def force(self, p):
+        f = np.zeros(1, dtype = {'names':p.names, 'formats':['f8' for _ in p.names]})
+        return f
 
 class GaussianTestCase(unittest.TestCase):
     """
     Test the gaussian model
     """
     def setUp(self):
-        self.work=cpnest.CPNest(GaussianModel(),verbose=0,Nthreads=4,Nlive=1000,maxmcmc=500,Poolsize=1000)
+        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=4,Nlive=1000,maxmcmc=1000,Poolsize=256)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_2d.py
+++ b/tests/test_2d.py
@@ -27,7 +27,7 @@ class GaussianTestCase(unittest.TestCase):
     Test the gaussian model
     """
     def setUp(self):
-        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=8,Nlive=1000,maxmcmc=1000,Poolsize=256)
+        self.work=cpnest.CPNest(GaussianModel(),verbose=3,Nthreads=1,Nlive=1000,maxmcmc=1000,Poolsize=1000)
 
     def test_run(self):
         self.work.run()

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -14,7 +14,9 @@ class RingModel(cpnest.model.Model):
     @staticmethod
     def log_likelihood(x):
         return log_ring(x['x'],x['y'])
-
+    def force(self, p):
+        f = np.zeros(1, dtype = {'names':p.names, 'formats':['f8' for _ in p.names]})
+        return f
 
 def log_ring(x, y, radius=1.0, thickness=0.1):
     r = np.sqrt(x**2+y**2)
@@ -26,7 +28,7 @@ class RingTestCase(unittest.TestCase):
     """
     def setUp(self):
         self.model=RingModel()
-        self.work=cpnest.CPNest(self.model,verbose=0,Nthreads=4,Nlive=1000,maxmcmc=1000)
+        self.work=cpnest.CPNest(self.model,verbose=2,Nthreads=4,Nlive=1000,maxmcmc=1000)
         self.work.run()
 
 


### PR DESCRIPTION
This branch implements two hamiltonian jump proposals: (i) a prior-driven leapfrog; (ii) a constrained prior-driven leap frog with the lowest likelihood contour acting as a hard reflective boundary. the gradient of the likelihood is estimated empirically using a savitzy-golay filter to smooth the samples and then a spline interpolant. The pseudo-momenta distribution is estimate from the set_ensemble method.
the branch passes all implemented tests. a few more changes regard remotion of a for loop in the sampler and a check for acceptance in the nested sampling loop, where the algorithm would get stuck if no new samples where found. As a new requirement, the user must define a force class in his model, where the user manually defines the derivatives of the prior, which are always possible and simple to take analytically. alternatively, a null array of the kind

f = np.zeros(1, dtype = {'names':p.names, 'formats':['f8' for _ in p.names]})

can be implemented, which is equivalent to a free particle evolution, subject only to the prior bounds, which act as a reflective surface. With the hamiltonian proposals, the ACLs drop substantially, at the price of a higher computational cost (likelihood evaluation at each leap frog step to check the boundary). 