### PR TITLE
Work on allowing custom jump proposals

### DIFF
--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -23,8 +23,9 @@ class CPNest(object):
     balance_samplers: If False, more samples will come from threads sampling "fast" parts of parameter space.
                       This may cause bias if parts of your parameter space are more expensive than others.
                       Default: True    
+    proposal: cpnest.proposal.ProposalCycle object to use while sampling.
     """
-    def __init__(self,usermodel,Nlive=100,Poolsize=100,output='./',verbose=0,seed=None,maxmcmc=100,Nthreads=None,balance_samplers = True):
+    def __init__(self,usermodel,Nlive=100,Poolsize=100,output='./',verbose=0,seed=None,maxmcmc=100,Nthreads=None,balance_samplers = True, proposal=None):
         if Nthreads is None:
             Nthreads = mp.cpu_count()
         print('Running with {0} parallel threads'.format(Nthreads))
@@ -43,7 +44,7 @@ class CPNest(object):
 
         self.consumer_pipes = []
         for i in range(Nthreads):
-            sampler = Sampler(self.user,maxmcmc,verbose=verbose,output=output,poolsize=Poolsize,seed=self.seed+i )
+            sampler = Sampler(self.user,maxmcmc,verbose=verbose,output=output,poolsize=Poolsize,seed=self.seed+i, proposal=proposal)
             # We set up pipes between the nested sampling and the various sampler processes
             consumer, producer = mp.Pipe(duplex=True)
             self.consumer_pipes.append(consumer)

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -50,14 +50,30 @@ class ProposalCycle(EnsembleProposal):
     def __init__(self,proposals,weights,cyclelength=100,*args,**kwargs):
         super(ProposalCycle,self).__init__(*args,**kwargs)
         assert(len(weights)==len(proposals))
-        # Normalise the weights
-        norm = sum(weights)
-        for i,_ in enumerate(weights):
-            weights[i]=weights[i]/norm
-        self.proposals=proposals
+        self.cyclelength = cyclelength
+        self.weights = weights
+        self.proposals = proposals
+        self.set_cycle()
+
+    def set_cycle(self):
         # The cycle is a list of indices for self.proposals
-        self.cycle = np.random.choice(self.proposals, size = cyclelength, p=weights, replace=True)
+        self.cycle = np.random.choice(self.proposals, size=self.cyclelength,
+                                      p=self.weights, replace=True)
         self.N=len(self.cycle)
+
+    @property
+    def weights(self):
+        return self._weights
+
+    @weights.setter
+    def weights(self, weights):
+        self._weights = self.normalise_weights(weights)
+
+    def normalise_weights(self, weights):
+        norm = sum(weights)
+        for i, _ in enumerate(weights):
+            weights[i]=weights[i] / norm
+        return weights
 
     def get_sample(self,old):
         # Call the current proposal and increment the index
@@ -73,6 +89,12 @@ class ProposalCycle(EnsembleProposal):
         for p in self.proposals:
             if isinstance(p,EnsembleProposal):
                 p.set_ensemble(self.ensemble)
+
+    def add_proposal(self, proposal, weight):
+        self.proposals = self.proposals + [proposal]
+        self.weights = self.weights + [weight]
+        self.set_cycle()
+
 
 class EnsembleWalk(EnsembleProposal):
     """


### PR DESCRIPTION
(1) Adds a `proposal` argument to `CPNest`
(2) Adds a `add_proposal` method to `ProposalCycle` so that users can
add cusom proposals and then pass them in via the `proposal` argument.

I've tested this works with a simple example. I'm not sure if I've understood the difference between a `proposal` and `proposal_cycle`. Comments/changes welcome. 