### PR TITLE
Make random calls safe

### DIFF
--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -131,7 +131,7 @@ class EnsembleWalk(EnsembleProposal):
         ----------
         out: :obj:`cpnest.parameter.LivePoint`
         """
-        subset = sample(self.ensemble,self.Npoints)
+        subset = sample(list(self.ensemble),self.Npoints)
         center_of_mass = reduce(type(old).__add__,subset)/float(self.Npoints)
         out = old
         for x in subset:
@@ -155,7 +155,7 @@ class EnsembleStretch(EnsembleProposal):
         """
         scale = 2.0 # Will stretch factor in (1/scale,scale)
         # Pick a random point to move toward
-        a = random.choice(self.ensemble)
+        a = random.choice(list(self.ensemble))
         # Pick the scale factor
         x = uniform(-1,1)*log(scale)
         Z = exp(x)
@@ -185,7 +185,7 @@ class DifferentialEvolution(EnsembleProposal):
         ----------
         out: :obj:`cpnest.parameter.LivePoint`
         """
-        a,b = sample(self.ensemble,2)
+        a,b = sample(list(self.ensemble),2)
         sigma = 1e-4 # scatter around difference vector by this factor
         out = old + (b-a)*gauss(1.0,sigma)
         return out

--- a/cpnest/proposal.py
+++ b/cpnest/proposal.py
@@ -155,7 +155,7 @@ class EnsembleStretch(EnsembleProposal):
         """
         scale = 2.0 # Will stretch factor in (1/scale,scale)
         # Pick a random point to move toward
-        a = random.choice(list(self.ensemble))
+        a = random.choice(self.ensemble)
         # Pick the scale factor
         x = uniform(-1,1)*log(scale)
         Z = exp(x)


### PR DESCRIPTION
This should resolve https://github.com/johnveitch/cpnest/issues/39.

In python3.4 the calls to `random.sample` required `list`s to be passed, not `dict`s.

I'm not sure why this isn't failing for python3.6, the error should be raised there too.

https://github.com/python/cpython/blob/3.4/Lib/random.py#L311
https://github.com/python/cpython/blob/3.4/Lib/random.py#L316