### PR TITLE
Adds a periodic checkpoint which is user-configurable

### DIFF
--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -121,10 +121,15 @@ class NestedSampler(object):
     prior_sampling: boolean
         produce Nlive samples from the prior.
         Default: False
-        
+
     stopping: float
         Stop when remaining samples wouldn't change logZ estimate by this much.
         Deafult: 0.1
+
+    n_periodic_checkpoint: int
+        checkpoint the sampler every n_periodic_checkpoint iterations
+        Default: 100000
+ 
     """
 
     def __init__(self,
@@ -135,7 +140,8 @@ class NestedSampler(object):
                  verbose        = 1,
                  seed           = 1,
                  prior_sampling = False,
-                 stopping       = 0.1):
+                 stopping       = 0.1,
+                 n_periodic_checkpoint = 100000):
         """
         Initialise all necessary arguments and
         variables for the algorithm
@@ -151,6 +157,7 @@ class NestedSampler(object):
         self.queue_counter  = 0
         self.Nlive          = nlive
         self.params         = [None] * self.Nlive
+        self.n_periodic_checkpoint = n_periodic_checkpoint
         self.tolerance      = stopping
         self.condition      = np.inf
         self.worst          = 0
@@ -312,7 +319,9 @@ class NestedSampler(object):
 
         try:
             while self.condition > self.tolerance:
-                self.consume_sample()
+                for _ in range(self.n_periodic_checkpoint):
+                    self.consume_sample()
+                self.checkpoint()
         except CheckPoint:
             self.checkpoint()
             sys.exit()
@@ -348,7 +357,6 @@ class NestedSampler(object):
         print('Checkpointing nested sampling')
         with open(self.resume_file,"wb") as f:
             pickle.dump(self, f)
-        sys.exit(0)
 
     @classmethod
     def resume(cls, filename, manager, usermodel):

--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -141,7 +141,7 @@ class NestedSampler(object):
                  seed           = 1,
                  prior_sampling = False,
                  stopping       = 0.1,
-                 n_periodic_checkpoint = 100000):
+                 n_periodic_checkpoint = 1000):
         """
         Initialise all necessary arguments and
         variables for the algorithm
@@ -319,7 +319,7 @@ class NestedSampler(object):
 
         try:
             while self.condition > self.tolerance:
-                for _ in range(self.n_periodic_checkpoint):
+                for i in range(self.n_periodic_checkpoint):
                     self.consume_sample()
                 self.checkpoint()
         except CheckPoint:

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -57,7 +57,7 @@ class CPNest(object):
                  nhamiltonian = 0,
                  resume       = False,
                  proposals     = None,
-                 n_periodic_checkpoint = 100000):
+                 n_periodic_checkpoint = 1000):
         if nthreads is None:
             self.nthreads = mp.cpu_count()
         else:
@@ -117,6 +117,7 @@ class CPNest(object):
                                   resume_file = resume_file,
                                   manager     = self.manager
                                   )
+                sampler.checkpoint()
             else:
                 sampler = MetropolisHastingsSampler.resume(resume_file,
                                                            self.manager,

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -40,6 +40,10 @@ class CPNest(object):
     resume: determines whether cpnest will resume a run or run from scratch. Default: False.
     proposal: dictionary/list with custom jump proposals. key 'mhs' for the
     Metropolis-Hastings sampler, 'hmc' for the Hamiltonian Monte-Carlo sampler. Default: None
+    n_periodic_checkpoint: int
+        checkpoint the sampler every n_periodic_checkpoint iterations
+        Default: 100000
+ 
     """
     def __init__(self,
                  usermodel,
@@ -52,7 +56,8 @@ class CPNest(object):
                  nthreads     = None,
                  nhamiltonian = 0,
                  resume       = False,
-                 proposals     = None):
+                 proposals     = None,
+                 n_periodic_checkpoint = 100000):
         if nthreads is None:
             self.nthreads = mp.cpu_count()
         else:
@@ -93,7 +98,8 @@ class CPNest(object):
                         verbose        = verbose,
                         seed           = self.seed,
                         prior_sampling = False,
-                        manager        = self.manager)
+                        manager        = self.manager,
+                        n_periodic_checkpoint = n_periodic_checkpoint)
         else:
             self.NS = NestedSampler.resume(resume_file, self.manager, self.user)
 
@@ -147,6 +153,7 @@ class CPNest(object):
             signal.signal(signal.SIGTERM, sighandler)
             signal.signal(signal.SIGQUIT, sighandler)
             signal.signal(signal.SIGINT, sighandler)
+            signal.signal(signal.SIGUSR1, sighandler)
             signal.signal(signal.SIGUSR2, sighandler)
         
         #self.p_ns.start()

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -210,7 +210,6 @@ class Sampler(object):
         print('Checkpointing Sampler')
         with open(self.resume_file, "wb") as f:
             pickle.dump(self, f)
-        sys.exit(0)
 
     @classmethod
     def resume(cls, resume_file, manager, model):


### PR DESCRIPTION
While the checkpoint stores the run on a sensible kill signal, often things
get ended without a nice signal being sent. This ensures that the
progress is periodically updated so that such a pre-empted run be restarted
from the last checkpoint.

Closes #47 