### PR TITLE
Improvements to checkpointing

### DIFF
--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -321,8 +321,9 @@ class NestedSampler(object):
             i=0
             while self.condition > self.tolerance:
                 self.consume_sample()
-                if self.n_periodic_checkpoint and i % self.n_periodic_checkpoint == 1:
+                if self.n_periodic_checkpoint is not None and i % self.n_periodic_checkpoint == 1:
                     self.checkpoint()
+                i += 1
         except CheckPoint:
             self.checkpoint()
             sys.exit()

--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -326,9 +326,12 @@ class NestedSampler(object):
                 i += 1
         except CheckPoint:
             self.checkpoint()
+            # Run each pipe to get it to checkpoint
+            for c in self.manager.consumer_pipes:
+                c.send("checkpoint")
             sys.exit()
 
-	    # Signal worker threads to exit
+        # Signal worker threads to exit
         self.logLmin.value = np.inf
         for c in self.manager.consumer_pipes:
             c.send(None)

--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -329,7 +329,7 @@ class NestedSampler(object):
             # Run each pipe to get it to checkpoint
             for c in self.manager.consumer_pipes:
                 c.send("checkpoint")
-            sys.exit()
+            sys.exit(130)
 
         # Signal worker threads to exit
         self.logLmin.value = np.inf

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -13,14 +13,17 @@ from multiprocessing import Lock
 from multiprocessing.managers import SyncManager
 
 import cProfile
-import time
-import os
+
 
 class CheckPoint(Exception):
+    print("Checkpoint exception raise")
     pass
 
+
 def sighandler(signal, frame):
-    raise CheckPoint
+    print("Handling signal {}".format(signal))
+    raise CheckPoint()
+
 
 class CPNest(object):
     """
@@ -258,6 +261,7 @@ class CPNest(object):
 
     def checkpoint(self):
         self.manager.checkpoint_flag=1
+
 
 class RunManager(SyncManager):
     def __init__(self, nthreads=None, **kwargs):

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -169,7 +169,7 @@ class CPNest(object):
                 each.join()
         except CheckPoint:
             self.checkpoint()
-            sys.exit()
+            sys.exit(130)
 
         self.posterior_samples = self.get_posterior_samples(filename=None)
         if self.verbose>1: self.plot()

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -151,6 +151,7 @@ class CPNest(object):
         """
         if self.resume:
             signal.signal(signal.SIGTERM, sighandler)
+            signal.signal(signal.SIGALRM, sighandler)
             signal.signal(signal.SIGQUIT, sighandler)
             signal.signal(signal.SIGINT, sighandler)
             signal.signal(signal.SIGUSR1, sighandler)

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -5,7 +5,6 @@ import numpy as np
 from math import log
 from collections import deque
 from random import random,randrange
-import signal
 
 from . import parameter
 from .proposal import DefaultProposalCycle
@@ -153,6 +152,7 @@ class Sampler(object):
         try:
             self._produce_sample()
         except CheckPoint:
+            print("Checkpoint excepted in sampler")
             self.checkpoint()
     
     def _produce_sample(self):
@@ -179,6 +179,9 @@ class Sampler(object):
 
             if p is None:
                 break
+            if p == "checkpoint":
+                self.checkpoint()
+                sys.exit()
         
             self.evolution_points.append(p)
             (Nmcmc, outParam) = next(self.yield_sample(self.logLmin.value))

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -170,7 +170,7 @@ class Sampler(object):
             
             if self.manager.checkpoint_flag.value:
                 self.checkpoint()
-                sys.exit()
+                sys.exit(130)
             
             if self.logLmin.value==np.inf:
                 break
@@ -181,7 +181,7 @@ class Sampler(object):
                 break
             if p == "checkpoint":
                 self.checkpoint()
-                sys.exit()
+                sys.exit(130)
         
             self.evolution_points.append(p)
             (Nmcmc, outParam) = next(self.yield_sample(self.logLmin.value))


### PR DESCRIPTION
This fixes a number of issues in the previous checkpointing.

1. Handle SIGALRM: this is useful when running on a cluster and periodic evictions need to be perfermed
2. Exit on 130: again, on HTCondor clusters, these periodic evictions can return a specific signal to indicate that the job is periodically evicting itself, I've hardwired this to 130.
3. Pass down the signal exit to the pipes: I found that when raising a SIGTERM or SIGALRM, the process hung and didn't communicate the change vis the `checkpoint_flag`. Instead, I've implemented a direct pass down of a string `" checkpoint"` to make it do so
4. Fix `n_periodic_checkpoint`: the previous implementation was not updating the counter and hence never periodically saving the data.