### PR TITLE
Patched build to run on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools.command.build_ext import build_ext as _build_ext
 from codecs import open
 import os
 import re
+import platform
+
+WINDOWS = platform.system().lower() == "windows"
 
 
 # see https://stackoverflow.com/a/21621689/1862861 for why this is here
@@ -27,18 +30,19 @@ else:
     have_cython = True
 
 # set extension
+libraries = [] if WINDOWS else ["m"]
 if have_cython:  # convert the pyx file to a .c file if cython is available
     ext_modules = [Extension("cpnest.parameter",
-                             sources=["cpnest/parameter.pyx"],
-                             include_dirs=['cpnest/'],
-                             libraries=['m'])]
+                             sources=[os.path.join("cpnest", "parameter.pyx")],
+                             include_dirs=['cpnest'],
+                             libraries=libraries)]
 else:
     # just compile the included parameter.c (already converted from
     # parameter.pyx) file
     ext_modules = [Extension("cpnest.parameter",
-                             sources=["cpnest/parameter.c"],
-                             include_dirs=['cpnest/'],
-                             libraries=['m'])]
+                             sources=[os.path.join("cpnest", "parameter.c")],
+                             include_dirs=['cpnest'],
+                             libraries=libraries)]
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
This PR patches `setup.py` to build on Windows; the main point is to not link against `libm` on windows, and to use platform-independent paths (not strictly required to build, but good practice).