### PR TITLE
make logLmax global

### DIFF
--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -299,11 +299,13 @@ class RunManager(SyncManager):
             self.producer_pipes.append(producer)
             self.consumer_pipes.append(consumer)
         self.logLmin=None
+        self.logLmax = None
         self.nthreads=nthreads
 
     def start(self):
         super(RunManager, self).start()
         self.logLmin = mp.Value(c_double,-np.inf)
+        self.logLmax = mp.Value(c_double,-np.inf)
         self.checkpoint_flag=mp.Value(c_int,0)
 
     def connect_producer(self):


### PR DESCRIPTION
This MR would make the `logLmax` used internally the maximum likelihood computed across the run.

I've done some tests that show that this improves the convergence in some instances, specifically, I looked at a 10D Rosenbrock where the max likelihood value found with the default `Bilby` setup increased from ~-10 to ~-0.5 with this change (the actual value is 0).

It also gives a better estimate of `dZ` earlier in the run.