### PR TITLE
WIP: Update logger for nest2pos

### DIFF
--- a/cpnest/__init__.py
+++ b/cpnest/__init__.py
@@ -1,4 +1,8 @@
+import logging
+from .logger import CPNestLogger
 from .cpnest import CPNest
+
+logging.setLoggerClass(CPNestLogger)
 
 __version__ = '0.9.8'
 
@@ -9,4 +13,6 @@ __all__ = ['model',
            'cpnest',
            'nest2pos',
            'proposal',
-           'plot']
+           'plot',
+           'logger']
+

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -7,17 +7,13 @@ import numpy as np
 import os
 import sys
 import signal
+import logging
 
 from multiprocessing.sharedctypes import Value, Array
 from multiprocessing import Lock
 from multiprocessing.managers import SyncManager
 
 import cProfile
-
-from .logger import start_logger, update_logger
-
-
-LOGGER = start_logger()
 
 
 class CheckPoint(Exception):
@@ -99,7 +95,8 @@ class CPNest(object):
         output = os.path.join(output, '')
         os.makedirs(output, exist_ok=True)
 
-        self.logger = update_logger(LOGGER, output=output, verbose=verbose)
+        self.logger = logging.getLogger('CPNest')
+        self.logger.update(output=output, verbose=verbose)
         self.logger.critical('Running with {0} parallel threads'.format(self.nthreads))
 
         from .sampler import HamiltonianMonteCarloSampler, MetropolisHastingsSampler

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -14,7 +14,10 @@ from multiprocessing.managers import SyncManager
 
 import cProfile
 
-from .logger import start_logger
+from .logger import start_logger, update_logger
+
+
+LOGGER = start_logger()
 
 
 class CheckPoint(Exception):
@@ -25,6 +28,7 @@ class CheckPoint(Exception):
 def sighandler(signal, frame):
     print("Handling signal {}".format(signal))
     raise CheckPoint()
+
 
 class CPNest(object):
     """
@@ -95,9 +99,9 @@ class CPNest(object):
         output = os.path.join(output, '')
         os.makedirs(output, exist_ok=True)
 
-        self.logger = start_logger(output, verbose=verbose)
-
+        self.logger = update_logger(LOGGER, output=output, verbose=verbose)
         self.logger.critical('Running with {0} parallel threads'.format(self.nthreads))
+
         from .sampler import HamiltonianMonteCarloSampler, MetropolisHastingsSampler
         from .NestedSampling import NestedSampler
         from .proposal import DefaultProposalCycle, HamiltonianProposalCycle

--- a/cpnest/logger.py
+++ b/cpnest/logger.py
@@ -1,6 +1,9 @@
 import logging
 
-def start_logger(output=None, verbose=0):
+FMT = '%(asctime)s - %(name)-8s: %(message)s'
+LEVELS = ['CRITICAL', 'WARNING', 'INFO', 'DEBUG']
+
+def start_logger(output=None, verbose=0, name='CPNest'):
     """
     Start an instance of Logger for logging
 
@@ -10,28 +13,43 @@ def start_logger(output=None, verbose=0):
     verbose: `int`
         Verbosity, 0=CRITICAL, 1=WARNING, 2=INFO, 3=DEBUG
 
-    fmt: `str`
-        format for logger (None) See logging documentation for details
-
+    name   : `str`
+        Name of the logger (CPnest)
     """
-    # possible levels
     verbose = min(verbose, 3)
     # levels 0, 1, 2, 3
-    levels = ['CRITICAL', 'WARNING', 'INFO', 'DEBUG']
-    level = levels[verbose]
-    fmt = '%(asctime)s - %(name)-8s: %(message)s'
+    level = LEVELS[verbose]
     # setup logger
-    logger = logging.getLogger('CPNest')
+    logger = logging.getLogger(name)
     logger.setLevel(level)
     # handle command line output
     ch = logging.StreamHandler()
-    ch.setFormatter(logging.Formatter(fmt, datefmt='%Y-%m-%d, %H:%M:%S'))
+    ch.setFormatter(logging.Formatter(FMT, datefmt='%Y-%m-%d, %H:%M:%S'))
     logger.addHandler(ch)
 
+    # log to file
     if output is not None:
-        # log to file
-        fh = logging.FileHandler(output + 'cpnest.log')
-        fh.setFormatter(logging.Formatter(fmt, datefmt='%Y-%m-%d, %H:%M:%S'))
-        logger.addHandler(fh)
-    print(logger.critical('Logging level: {}'.format(level)))
+        add_file_handler(logger, output)
+
+    logger.warning('Logging level: {}'.format(level))
     return logger
+
+def add_file_handler(logger, output):
+    """Add a file handler to a logger"""
+    fh = logging.FileHandler(output + 'cpnest.log')
+    fh.setFormatter(logging.Formatter(FMT, datefmt='%Y-%m-%d, %H:%M:%S'))
+    logger.addHandler(fh)
+    return logger
+
+def update_logger(logger, verbose=None, output=None):
+    """Update the verbosity and/or add an output file"""
+    if output is not None:
+        add_file_handler(logger, output)
+    if verbose is not None:
+        level = LEVELS[verbose]
+        logger.setLevel(level)
+        # update any handlers
+        for handler in logger.handlers:
+            handler.setLevel(level)
+    return logger
+

--- a/cpnest/logger.py
+++ b/cpnest/logger.py
@@ -1,73 +1,52 @@
 import logging
 
-FMT = '%(asctime)s - %(name)-8s: %(message)s'
-LEVELS = ['CRITICAL', 'WARNING', 'INFO', 'DEBUG']
+class CPNestLogger(logging.Logger):
 
-def start_logger(output=None, verbose=0, name='CPNest'):
-    """
-    Start an instance of Logger for logging
+    def __init__(self, name):
 
-    output : `str`
-        output directory (./)
+        super(CPNestLogger, self).__init__(name)
 
-    verbose: `int`
-        Verbosity, 0=CRITICAL, 1=WARNING, 2=INFO, 3=DEBUG
+        self.fmt = '%(asctime)s - %(name)-8s: %(message)s'
+        self.date_fmt = '%Y-%m-%d, %H:%M:%S'
+        self.levels = ['CRITICAL', 'WARNING', 'INFO', 'DEBUG']
+        self.add_stream_handler()
 
-    name   : `str`
-        Name of the logger (CPnest)
-    """
-    verbose = min(verbose, 3)
-    # levels 0, 1, 2, 3
-    level = LEVELS[verbose]
-    # setup logger
-    logger = logging.getLogger(name)
-    logger.setLevel(level)
-    # handle command line output
-    ch = logging.StreamHandler()
-    ch.setFormatter(logging.Formatter(FMT, datefmt='%Y-%m-%d, %H:%M:%S'))
-    logger.addHandler(ch)
+    def add_file_handler(self, output):
+        """
+        Add a file handler
 
-    # log to file
-    if output is not None:
-        add_file_handler(logger, output)
+        output : `str`
+            Output directory
+        """
+        fh = logging.FileHandler(output + 'cpnest.log')
+        fh.setFormatter(logging.Formatter(self.fmt, datefmt=self.date_fmt))
+        self.addHandler(fh)
 
-    logger.warning('Logging level: {}'.format(level))
-    return logger
+    def add_stream_handler(self):
+        """
+        Add a stream handler
+        """
+        sh = logging.StreamHandler()
+        sh.setFormatter(logging.Formatter(self.fmt, datefmt=self.date_fmt))
+        self.addHandler(sh)
 
-def add_file_handler(logger, output):
-    """
-    Add a file handler to a logger
+    def update(self, output=None, verbose=0):
+        """
+        Update the verbosity and/or add an output file
 
-    logger : `obj`
-        Instance of logging.Logger
+        verbose: `int`
+            Verbosity, 0=CRITICAL, 1=WARNING, 2=INFO, 3=DEBUG
 
-    output : `str`
-        Output directory
-    """
-    fh = logging.FileHandler(output + 'cpnest.log')
-    fh.setFormatter(logging.Formatter(FMT, datefmt='%Y-%m-%d, %H:%M:%S'))
-    logger.addHandler(fh)
-    return logger
-
-def update_logger(logger, verbose=None, output=None):
-    """
-    Update the verbosity and/or add an output file
-
-    logger : `obj`
-        Instance of logging.Logger
-
-    verbose: `int`
-        Verbosity, 0=CRITICAL, 1=WARNING, 2=INFO, 3=DEBUG
-
-    output : `str`
-        Output directory
-    """
-    if output is not None:
-        add_file_handler(logger, output)
-    if verbose is not None:
-        level = LEVELS[verbose]
-        logger.setLevel(level)
-        # update any handlers
-        for handler in logger.handlers:
-            handler.setLevel(level)
-    return logger
+        output : `str`
+            Output directory
+        """
+        verbose = min(verbose, 3)
+        if output is not None:
+            self.add_file_handler(output)
+        if verbose is not None:
+            level = self.levels[verbose]
+            self.setLevel(level)
+            # update any handlers
+            for handler in self.handlers:
+                handler.setLevel(level)
+        self.warning('Setting verbosity to {}'.format(verbose))

--- a/cpnest/logger.py
+++ b/cpnest/logger.py
@@ -1,6 +1,21 @@
 import logging
 
 class CPNestLogger(logging.Logger):
+    """
+    Custom logger class that inherits from the Logger class and is called when
+    instantiating a logger with the logging package in CPNest.
+
+    It includes a stream handler by default and can be updated to change
+    verbosity and/or log to a file.
+    ---------
+
+    Initialisation arguments:
+
+    args:
+
+    name:
+        :str: name of the logger
+    """
 
     def __init__(self, name):
 

--- a/cpnest/logger.py
+++ b/cpnest/logger.py
@@ -35,14 +35,33 @@ def start_logger(output=None, verbose=0, name='CPNest'):
     return logger
 
 def add_file_handler(logger, output):
-    """Add a file handler to a logger"""
+    """
+    Add a file handler to a logger
+
+    logger : `obj`
+        Instance of logging.Logger
+
+    output : `str`
+        Output directory
+    """
     fh = logging.FileHandler(output + 'cpnest.log')
     fh.setFormatter(logging.Formatter(FMT, datefmt='%Y-%m-%d, %H:%M:%S'))
     logger.addHandler(fh)
     return logger
 
 def update_logger(logger, verbose=None, output=None):
-    """Update the verbosity and/or add an output file"""
+    """
+    Update the verbosity and/or add an output file
+
+    logger : `obj`
+        Instance of logging.Logger
+
+    verbose: `int`
+        Verbosity, 0=CRITICAL, 1=WARNING, 2=INFO, 3=DEBUG
+
+    output : `str`
+        Output directory
+    """
     if output is not None:
         add_file_handler(logger, output)
     if verbose is not None:
@@ -52,4 +71,3 @@ def update_logger(logger, verbose=None, output=None):
         for handler in logger.handlers:
             handler.setLevel(level)
     return logger
-

--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -4,7 +4,10 @@ from numpy import logaddexp, vstack
 from numpy.random import uniform
 from functools import reduce
 
-LOGGER = logging.getLogger("CPNest")
+if not logging.Logger.manager.loggerDict:
+    LOGGER = logging.getLogger('nest2pos')
+else:
+    LOGGER = logging.getLogger('cpnest')
 
 def logsubexp(x,y):
     """
@@ -20,6 +23,7 @@ def logsubexp(x,y):
         z: :float: x + np.log1p(-np.exp(y-x))
     """
     assert np.all(x >= y), 'cannot take log of negative number {0!s} - {1!s}'.format(str(x), str(y))
+    LOGGER.critical([x, y])
     return x + np.log1p(-np.exp(y-x))
 
 def log_integrate_log_trap(log_func,log_support):

--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -4,7 +4,7 @@ from numpy import logaddexp, vstack
 from numpy.random import uniform
 from functools import reduce
 
-logger = logging.getLogger("CPNest")
+LOGGER = logging.getLogger("CPNest")
 
 def logsubexp(x,y):
     """
@@ -20,7 +20,6 @@ def logsubexp(x,y):
         z: :float: x + np.log1p(-np.exp(y-x))
     """
     assert np.all(x >= y), 'cannot take log of negative number {0!s} - {1!s}'.format(str(x), str(y))
-
     return x + np.log1p(-np.exp(y-x))
 
 def log_integrate_log_trap(log_func,log_support):
@@ -80,27 +79,27 @@ def draw_posterior_many(datas, Nlives, verbose=False):
     and weight according to the evidence in each input run"""
     # list of log_evidences, log_weights
     log_evs,log_wts=zip(*[compute_weights(data['logL'],Nlive) for data,Nlive in zip(datas, Nlives)])
-    logger.critical('Computed log_evidences: {0!s}'.format((str(log_evs))))
+    LOGGER.critical('Computed log_evidences: {0!s}'.format((str(log_evs))))
 
     log_total_evidence=reduce(logaddexp, log_evs)
     log_max_evidence=max(log_evs)
     #print 'evidences: %s'%(str(log_evs))
     fracs=[np.exp(log_ev-log_max_evidence) for log_ev in log_evs]
-    logger.critical('Relative weights of input files: {0!s}'.format((str(fracs))))
+    LOGGER.critical('Relative weights of input files: {0!s}'.format((str(fracs))))
     Ns=[fracs[i]/len(datas[i]) for i in range(len(fracs))]
     Ntot=max(Ns)
     fracs=[n/Ntot for n in Ns]
-    logger.critical('Relative weights of input files taking into account their length: {0!s}'.format((str(fracs))))
+    LOGGER.critical('Relative weights of input files taking into account their length: {0!s}'.format((str(fracs))))
 
     posts=[draw_posterior(data,logwt) for (data,logwt,logZ) in zip(datas,log_wts,log_evs)]
-    logger.critical('Number of input samples: {0!s}'.format((str([len(x) for x in log_wts]))))
-    logger.critical('Expected number of samples from each input file {0!s}'.format((str([int(f*len(p)) for f,p in zip(fracs,posts)]))))
+    LOGGER.critical('Number of input samples: {0!s}'.format((str([len(x) for x in log_wts]))))
+    LOGGER.critical('Expected number of samples from each input file {0!s}'.format((str([int(f*len(p)) for f,p in zip(fracs,posts)]))))
     bigpos=[]
     for post,frac in zip(posts,fracs):
       mask = uniform(size=len(post))<frac
       bigpos.append(post[mask])
     result = vstack(bigpos).flatten()
-    logger.critical('Samples produced: {0:d}'.format(result.shape[0]))
+    LOGGER.critical('Samples produced: {0:d}'.format(result.shape[0]))
     return result
 
 def draw_N_posterior(data,log_wts, N, verbose=False):
@@ -139,7 +138,7 @@ def redraw_mcmc_chain(chain, verbose=False, burnin=True):
     Draw samples from the mcmc chains posteriors by redrawing
     each one of them against the Metropolis-Hastings rule
     """
-    logger.critical('Number of input samples: {0!s}'.format(chain.shape[0]))
+    LOGGER.critical('Number of input samples: {0!s}'.format(chain.shape[0]))
     if burnin: chain = chain[chain.shape[0]/2-1:]
     ACL = []
     for n in chain.dtype.names:
@@ -148,7 +147,7 @@ def redraw_mcmc_chain(chain, verbose=False, burnin=True):
             ACL.append(acl(acf))
     ACL = int(np.round(np.max(ACL)))
 
-    logger.critical('Measured autocorrelation length {0!s}'.format(str(ACL)))
+    LOGGER.critical('Measured autocorrelation length {0!s}'.format(str(ACL)))
     chain = chain[::ACL]
     logpost = chain['logL']+chain['logPrior']
     # reweight using the MH rule
@@ -156,7 +155,7 @@ def redraw_mcmc_chain(chain, verbose=False, burnin=True):
     dlp = np.diff(logpost)
     (idx,) = np.where(dlp > us)
     chain = chain[idx+1]
-    logger.critical('Returned number of samples {0!s}'.format(str(chain.shape[0])))
+    LOGGER.critical('Returned number of samples {0!s}'.format(str(chain.shape[0])))
 
     return chain
 

--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -23,7 +23,6 @@ def logsubexp(x,y):
         z: :float: x + np.log1p(-np.exp(y-x))
     """
     assert np.all(x >= y), 'cannot take log of negative number {0!s} - {1!s}'.format(str(x), str(y))
-    LOGGER.critical([x, y])
     return x + np.log1p(-np.exp(y-x))
 
 def log_integrate_log_trap(log_func,log_support):

--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -7,7 +7,7 @@ from functools import reduce
 if not logging.Logger.manager.loggerDict:
     LOGGER = logging.getLogger('nest2pos')
 else:
-    LOGGER = logging.getLogger('cpnest')
+    LOGGER = logging.getLogger('CPNest')
 
 def logsubexp(x,y):
     """

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -79,7 +79,7 @@ class Sampler(object):
         self.logLmin = self.manager.logLmin
         self.logLmax = self.manager.logLmax
 
-        self.logger         = logging.getLogger('CPNest')
+        self.logger = logging.getLogger('CPNest')
 
         if proposal is None:
             self.proposal = DefaultProposalCycle()


### PR DESCRIPTION
Improves the logger's behaviour when using nest2pos without initialising an instance of CPNest.
 
* Uses a global logger with default `verbose=0`
* Logger is updated when initialising an instance of CPNest so that output is saved and verbosity updated
* Changes to using `LOGGER` for global instead of `logger`