### PR TITLE
require python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         url='https://github.com/johnveitch/cpnest',
         license='MIT',
         cmdclass={'build_ext': build_ext},
+        python_requires='>=3',
         classifiers=[
             'Development Status :: 4 - Beta',
             'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
The current code should require that python3 be installed. It is only listed in the classifier section, however these are only for searching purposes and are not used. 

See https://packaging.python.org/guides/distributing-packages-using-setuptools/#classifiers