### PR TITLE
Periodic checkpointing

### DIFF
--- a/cpnest/NestedSampling.py
+++ b/cpnest/NestedSampling.py
@@ -140,6 +140,8 @@ class NestedSampler(object):
         Deafult: 0.1
 
     n_periodic_checkpoint: int
+        **deprecated**
+        This parameter should not be used, it should be set by the manager instead.
         checkpoint the sampler every n_periodic_checkpoint iterations
         Default: None (disabled)
 

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -364,6 +364,9 @@ class CPNest(object):
 
 class RunManager(SyncManager):
     def __init__(self, nthreads=None, **kwargs):
+        self.periodic_checkpoint_interval = kwargs.pop(
+            "periodic_checkpoint_interval", np.inf
+        )
         super(RunManager,self).__init__(**kwargs)
         self.nconnected=mp.Value(c_int,0)
         self.producer_pipes = list()
@@ -375,9 +378,6 @@ class RunManager(SyncManager):
         self.logLmin = None
         self.logLmax = None
         self.nthreads=nthreads
-        self.periodic_checkpoint_interval = kwargs.get(
-            "periodic_checkpoint_interval", np.inf
-        )
 
     def start(self):
         super(RunManager, self).start()

--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -70,7 +70,12 @@ class CPNest(object):
         'hmc' for the Hamiltonian Monte-Carlo sampler. Default: None
 
     n_periodic_checkpoint: `int`
+        **deprecated**
         checkpoint the sampler every n_periodic_checkpoint iterations
+        Default: None (disabled)
+    
+    periodic_checkpoint_interval: `float`
+        checkpoing the sampler every periodic_checkpoint_interval seconds
         Default: None (disabled)
 
     """

--- a/cpnest/sampler.py
+++ b/cpnest/sampler.py
@@ -2,6 +2,7 @@ from __future__ import division
 import sys
 import os
 import logging
+import time
 import numpy as np
 from math import log
 from collections import deque
@@ -101,6 +102,7 @@ class Sampler(object):
         self.output             = output
         self.samples            = [] # the list of samples from the mcmc chain
         self.producer_pipe, self.thread_id = self.manager.connect_producer()
+        self.last_checkpoint_time = time.time()
 
     def reset(self):
         """
@@ -192,7 +194,11 @@ class Sampler(object):
 
             if self.logLmin.value==np.inf:
                 break
-            
+
+            if time.time() - self.last_checkpoint_time > self.manager.periodic_checkpoint_interval:
+                self.checkpoint()
+                self.last_checkpoint_time = time.time()
+
             # if the nested sampler is requesting for an update
             # produce a sample for it
             if self.producer_pipe.poll():
@@ -255,6 +261,7 @@ class Sampler(object):
         obj.logger = logging.getLogger("CPNest")
         obj.producer_pipe , obj.thread_id = obj.manager.connect_producer()
         obj.logger.info('Resuming Sampler from ' + resume_file)
+        obj.last_checkpoint_time = time.time()
         return obj
 
     def __getstate__(self):


### PR DESCRIPTION
Hi @johnveitch, this MR is an improvement to the periodic checkpointing so that it actually happens periodically. The period at which checkpoints are written is specified by the user and is turned off by default. It will now dump the nested sampler and each of the individual samplers so they won't be lost if a job suddenly stops without going through the current checkpoint catch.

I also deprecated the current n_iterations based checkpointing, but I'm happy to undo that, I just figured it would be confusing to have both be possible.

I've tested this locally and also through HTCondor and the checkpoints write nicely and jobs resume after being evicted with and without the file transfer system.