### PR TITLE
Fix draw_posterior_many vstack call

### DIFF
--- a/cpnest/nest2pos.py
+++ b/cpnest/nest2pos.py
@@ -101,7 +101,7 @@ def draw_posterior_many(datas, Nlives, verbose=False):
     for post,frac in zip(posts,fracs):
       mask = uniform(size=len(post))<frac
       bigpos.append(post[mask])
-    result = vstack(bigpos).flatten()
+    result = np.concatenate([bigpos[i] for i in range(len(bigpos))], axis=None)
     LOGGER.critical('Samples produced: {0:d}'.format(result.shape[0]))
     return result
 


### PR DESCRIPTION
vstack cannot concatenate arrays of different size. As a consquence, calling draw_posterior_many with two different chains (which in general host a different number of samples) will result in the error: 

```ValueError: all the input array dimensions for the concatenation axis must match exactly, but along dimension 1, the array at index 0 has size X and the array at index 1 has size Y```

This can be simply fixed by concatenating the arrays instead of vstacking them.