### PR TITLE
Removed duplicated logger message

### DIFF
--- a/cpnest/cpnest.py
+++ b/cpnest/cpnest.py
@@ -267,8 +267,6 @@ class CPNest(object):
 
         with self.log_file:
             # Everything in this context is logged to `log_file`
-            msg = 'Running with {0} parallel threads'.format(self.nthreads)
-            self.logger.critical(msg)
 
             if self.resume:
                 signal.signal(signal.SIGTERM, sighandler)

--- a/cpnest/utils.py
+++ b/cpnest/utils.py
@@ -3,7 +3,7 @@ import logging
 
 # Default formats and level names
 FORMATTER = logging.Formatter(
-    '%(asctime)s - %(name)-8s: %(message)s',
+    '%(asctime)s - %(name)-38s: %(message)s',
     datefmt='%Y-%m-%d, %H:%M:%S'
 )
 LEVELS = ['CRITICAL', 'WARNING', 'INFO', 'DEBUG']


### PR DESCRIPTION
I left a duplicated logger message in which I used for testing PR #79 and have now removed it. Apologies for not spotting this earlier! I've double checked the rest of the code and edited the logger format to account for the longer logger names. I also managed to run the tests with python 3.7.