### PR TITLE
Fix Gaussian Mixture likelihood

### DIFF
--- a/examples/gaussianmixture.py
+++ b/examples/gaussianmixture.py
@@ -16,14 +16,14 @@ class GaussianMixtureModel(cpnest.model.Model):
                 data.append(np.random.normal(0.5,0.5))
             else:
                 data.append(np.random.normal(-1.5,0.03))
-        
+
         self.data = np.array(data)
-    
+
     def log_likelihood(self,x):
         w = x['weight']
-        logL1 = np.sum(np.log(w)-np.log(x['sigma1'])-0.5*((self.data-x['mean1'])/x['sigma1'])**2)
-        logL2 = np.sum(np.log(1.0-w)-np.log(x['sigma2'])-0.5*((self.data-x['mean2'])/x['sigma2'])**2)
-        logL = np.logaddexp(logL1,logL2)
+        logL1 = np.log(w)-np.log(x['sigma1'])-0.5*((self.data-x['mean1'])/x['sigma1'])**2
+        logL2 = np.log(1.0-w)-np.log(x['sigma2'])-0.5*((self.data-x['mean2'])/x['sigma2'])**2
+        logL = np.logaddexp(logL1, logL2).sum()
         return logL
 
     def log_prior(self,p):


### PR DESCRIPTION
The log-likelihood in the Gaussian mixture model example incorrectly sums across the samples of the individual Gaussians. As a result, the sampler would converge to a posterior distribution where the weight of each Gaussian (`w`) was either 0 or 1. This PR fixes the log-likelihood. 

See [here](http://www.astro.gla.ac.uk/~michael/misc/cpnest/gmm_example/) for the output from cpnest with the fix, the run took just over three hours.